### PR TITLE
set value to empty string when clearing input

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -26,7 +26,7 @@ $(document).ready(function(){
 
   	/*--- Clear guess field ---*/
   	var clearField = function() {
-	$("#userGuess").val(" ").focus();
+	$("#userGuess").val("").focus();
 	};
 
 	/*--- Show the number of guesses ---*/


### PR DESCRIPTION
a suggestion: when the input field is cleared using `""` rather than `" "`
`""` sets the value to be an empty string (nothing)
`" "` sets the value to be a single space

Try it out in the browser and get a feel for the difference when you click away from the field and back on it to type.
